### PR TITLE
Oven message fixes

### DIFF
--- a/apps/HomeConnect.groovy
+++ b/apps/HomeConnect.groovy
@@ -441,6 +441,9 @@ def processData(device, data) {
                     device.sendEvent(name: "DoorState", value: "${it.displayvalue}", displayed: true, isStateChange: true)
                     device.sendEvent(name: "contact", value: "${it.displayvalue.toLowerCase()}")
                 break
+                case "BSH.Common.Status.LocalControlActive":
+                    device.sendEvent(name: "RemoteControlActive", value: "${it.value}", displayed: true, isStateChange: true)
+                break
                 case "BSH.Common.Status.OperationState":
                     device.sendEvent(name: "OperationState", value: "${it.displayvalue}", displayed: true, isStateChange: true)
                 break
@@ -511,6 +514,9 @@ def processData(device, data) {
                 break
                 case "Cooking.Common.Option.Hood.IntensiveLevel":
                     device.sendEvent(name: "IntensiveLevel", value: "${it.value}", displayed: true, isStateChange: true)
+                break
+                case "Cooking.Oven.Status.CurrentCavityTemperature":
+                    device.sendEvent(name: "CurrentCavityTemperature", value: "${it.value}", displayed: true, isStateChange: true)
                 break
                 case "error":
                     device.sendEvent(name: "LastErrorMessage", value: "${Utils.convertErrorMessageTime(it.value?.description)}", displayed: true)

--- a/apps/HomeConnect.groovy
+++ b/apps/HomeConnect.groovy
@@ -442,7 +442,7 @@ def processData(device, data) {
                     device.sendEvent(name: "contact", value: "${it.displayvalue.toLowerCase()}")
                 break
                 case "BSH.Common.Status.LocalControlActive":
-                    device.sendEvent(name: "RemoteControlActive", value: "${it.value}", displayed: true, isStateChange: true)
+                    device.sendEvent(name: "LocalControlActive", value: "${it.value}", displayed: true, isStateChange: true)
                 break
                 case "BSH.Common.Status.OperationState":
                     device.sendEvent(name: "OperationState", value: "${it.displayvalue}", displayed: true, isStateChange: true)


### PR DESCRIPTION
Without this change, my oven was spamming the hubitat log file with hundreds of messages every time my oven was used (even for short periods of time).  While changing anything on the oven dial would cause local control error messages.  Essentially, every temperature change, would result in a stream of new "error" messages.  This PR allows the control and temperature messages to be handled and made available in the device for other use such as reading, graphing, etc.